### PR TITLE
Relax constraints on paper_trail

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     bullet_train-audit_logs (1.0.0)
       diffy (~> 3.4)
-      paper_trail (~> 14.0)
+      paper_trail (>= 14.0)
       rails (>= 6.0)
 
 GEM

--- a/bullet_train-audit_logs.gemspec
+++ b/bullet_train-audit_logs.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 6.0"
-  spec.add_dependency "paper_trail", "~> 14.0"
+  spec.add_dependency "paper_trail", ">= 14.0"
   spec.add_dependency "diffy", "~> 3.4"
 end


### PR DESCRIPTION
This makes it possible to install this gem with a version of `paper_trail` newer than `14.0.x`.