### PR TITLE
Bug fix for super scaffolding

### DIFF
--- a/lib/bullet_train/audit_logs/scaffolders/audit_logs_scaffolder.rb
+++ b/lib/bullet_train/audit_logs/scaffolders/audit_logs_scaffolder.rb
@@ -5,6 +5,16 @@ module BulletTrain
   module AuditLogs
     module Scaffolders
       class AuditLogScaffolder < SuperScaffolding::Scaffolder
+
+        # TODO this method was removed from the global scope in super scaffolding and moved to `Scaffolding::Transformer`,
+        # but this gem hasn't been updated yet.
+        def legacy_replace_in_file(file, before, after)
+          puts "Replacing in '#{file}'."
+          target_file_content = File.read(file)
+          target_file_content.gsub!(before, after)
+          File.write(file, target_file_content)
+        end
+
         def run
           if installation_has_not_been_run?
             puts install_message


### PR DESCRIPTION
Currently it's not possible to generate an audit log. This PR along with https://github.com/bullet-train-co/bullet_train-core/pull/945 fix that particular problem.

This is really just a quick and dirty fix to get things working as quickly as possible. Eventually we should remove this method and use whatever the new standard method is.