### PR TITLE
Fix for missing `versions` table

### DIFF
--- a/app/models/activity/version.rb
+++ b/app/models/activity/version.rb
@@ -1,4 +1,6 @@
-class Activity::Version < PaperTrail::Version
+class Activity::Version < ActiveRecord::Base
+  include PaperTrail::VersionConcern
+
   self.table_name = :activity_versions
   self.sequence_name = :activity_versions_id_seq
 


### PR DESCRIPTION
Fixes: https://github.com/bullet-train-pro/bullet_train-audit_logs/issues/7

It looks like we were doing what the PaperTrail docs suggest, but that's causing problems in a BT app for some reason. So far I've been unable to reproduce the problem in a minimal setup, but this fix gets things working again.

Seems likely related to this issue somehow:
https://github.com/paper-trail-gem/paper_trail/issues/1464